### PR TITLE
cleanup: split the main file accross files

### DIFF
--- a/nginx/clubs.iiit.ac.in.conf
+++ b/nginx/clubs.iiit.ac.in.conf
@@ -1,0 +1,44 @@
+upstream clubs.iiit.ac.in {
+	# Cannot connect to network 'cc-prod_default' of this container
+	## Can be connected with "reverse_proxy" network
+	# cc-prod-nginx-1
+	server 172.20.0.4:80;
+}
+
+server {
+	server_name clubs.iiit.ac.in life.iiit.ac.in;
+	listen 80 ;
+	access_log /var/log/nginx/access.log vhost;
+	# Do not HTTPS redirect Let'sEncrypt ACME challenge
+	location ^~ /.well-known/acme-challenge/ {
+		auth_basic off;
+		auth_request off;
+		allow all;
+		root /usr/share/nginx/html;
+		try_files $uri =404;
+		break;
+	}
+	location / {
+		return 301 https://$host$request_uri;
+	}
+}
+
+server {
+	server_name clubs.iiit.ac.in;
+	listen 443 ssl http2 ;
+	access_log /var/log/nginx/access.log vhost;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/nginx/certs/clubs.iiit.ac.in.crt;
+	ssl_certificate_key /etc/nginx/certs/clubs.iiit.ac.in.key;
+	ssl_dhparam /etc/nginx/certs/clubs.iiit.ac.in.dhparam.pem;
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	ssl_trusted_certificate /etc/nginx/certs/clubs.iiit.ac.in.chain.pem;
+	add_header Strict-Transport-Security "max-age=31536000" always;
+	include /etc/nginx/vhost.d/default;
+	location / {
+		proxy_pass http://clubs.iiit.ac.in;
+	}
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -27,11 +27,9 @@ map $proxy_x_forwarded_proto $proxy_x_forwarded_ssl {
 	https on;
 }
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-log_format vhost '$host $remote_addr - $remote_user [$time_local] '
-'"$request" $status $body_bytes_sent '
-'"$http_referer" "$http_user_agent" '
-'"$upstream_addr"';
+log_format vhost '$host $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$upstream_addr"';
 access_log off;
+
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
 ssl_prefer_server_ciphers off;
@@ -68,107 +66,4 @@ server {
 	ssl_session_tickets off;
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
-}
-upstream clubs.iiit.ac.in {
-	# Cannot connect to network 'cc-prod_default' of this container
-	## Can be connected with "reverse_proxy" network
-	# cc-prod-nginx-1
-	server 172.20.0.4:80;
-}
-server {
-	server_name clubs.iiit.ac.in life.iiit.ac.in;
-	listen 80 ;
-	access_log /var/log/nginx/access.log vhost;
-	# Do not HTTPS redirect Let'sEncrypt ACME challenge
-	location ^~ /.well-known/acme-challenge/ {
-		auth_basic off;
-		auth_request off;
-		allow all;
-		root /usr/share/nginx/html;
-		try_files $uri =404;
-		break;
-	}
-	location / {
-		return 301 https://$host$request_uri;
-	}
-}
-server {
-	server_name clubs.iiit.ac.in;
-	listen 443 ssl http2 ;
-	access_log /var/log/nginx/access.log vhost;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/clubs.iiit.ac.in.crt;
-	ssl_certificate_key /etc/nginx/certs/clubs.iiit.ac.in.key;
-	ssl_dhparam /etc/nginx/certs/clubs.iiit.ac.in.dhparam.pem;
-	ssl_stapling on;
-	ssl_stapling_verify on;
-	ssl_trusted_certificate /etc/nginx/certs/clubs.iiit.ac.in.chain.pem;
-	add_header Strict-Transport-Security "max-age=31536000" always;
-	include /etc/nginx/vhost.d/default;
-	location / {
-		proxy_pass http://clubs.iiit.ac.in;
-	}
-}
-server {
-	server_name life.iiit.ac.in;
-	listen 443 ssl http2 ;
-	access_log /var/log/nginx/access.log vhost;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
-	ssl_certificate /etc/ssl/iiit.ac.in.pem;
-	ssl_certificate_key /etc/ssl/iiit.ac.in.pem;
-	# ssl_dhparam /etc/ssl/certs/clubs.iiit.ac.in.dhparam.pem;
-	ssl_stapling on;
-	ssl_stapling_verify on;
-	ssl_trusted_certificate /etc/ssl/iiit.ac.in.pem;
-	add_header Strict-Transport-Security "max-age=31536000" always;
-	include /etc/nginx/vhost.d/default;
-	location / {
-		proxy_pass http://clubs.iiit.ac.in;
-	}
-}
-upstream dev.clubs.iiit.ac.in {
-	## Can be connected with "reverse_proxy" network
-	# cc-staging-nginx-1
-	server 172.20.0.5:80;
-	# Cannot connect to network 'cc-staging_default' of this container
-}
-server {
-	server_name dev.clubs.iiit.ac.in;
-	listen 80 ;
-	access_log /var/log/nginx/access.log vhost;
-	# Do not HTTPS redirect Let'sEncrypt ACME challenge
-	location ^~ /.well-known/acme-challenge/ {
-		auth_basic off;
-		auth_request off;
-		allow all;
-		root /usr/share/nginx/html;
-		try_files $uri =404;
-		break;
-	}
-	location / {
-		return 301 https://$host$request_uri;
-	}
-}
-server {
-	server_name dev.clubs.iiit.ac.in;
-	listen 443 ssl http2 ;
-	access_log /var/log/nginx/access.log vhost;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/clubs.iiit.ac.in.crt;
-	ssl_certificate_key /etc/nginx/certs/clubs.iiit.ac.in.key;
-	ssl_dhparam /etc/nginx/certs/clubs.iiit.ac.in.dhparam.pem;
-	ssl_stapling on;
-	ssl_stapling_verify on;
-	ssl_trusted_certificate /etc/nginx/certs/clubs.iiit.ac.in.chain.pem;
-	add_header Strict-Transport-Security "max-age=31536000" always;
-	include /etc/nginx/vhost.d/default;
-	location / {
-		proxy_pass http://dev.clubs.iiit.ac.in;
-	}
 }

--- a/nginx/dev.clubs.iiit.ac.in.conf
+++ b/nginx/dev.clubs.iiit.ac.in.conf
@@ -1,0 +1,42 @@
+upstream dev.clubs.iiit.ac.in {
+	## Can be connected with "reverse_proxy" network
+	# cc-staging-nginx-1
+	server 172.20.0.5:80;
+	# Cannot connect to network 'cc-staging_default' of this container
+}
+server {
+	server_name dev.clubs.iiit.ac.in;
+	listen 80 ;
+	access_log /var/log/nginx/access.log vhost;
+	# Do not HTTPS redirect Let'sEncrypt ACME challenge
+	location ^~ /.well-known/acme-challenge/ {
+		auth_basic off;
+		auth_request off;
+		allow all;
+		root /usr/share/nginx/html;
+		try_files $uri =404;
+		break;
+	}
+	location / {
+		return 301 https://$host$request_uri;
+	}
+}
+server {
+	server_name dev.clubs.iiit.ac.in;
+	listen 443 ssl http2 ;
+	access_log /var/log/nginx/access.log vhost;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/nginx/certs/clubs.iiit.ac.in.crt;
+	ssl_certificate_key /etc/nginx/certs/clubs.iiit.ac.in.key;
+	ssl_dhparam /etc/nginx/certs/clubs.iiit.ac.in.dhparam.pem;
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	ssl_trusted_certificate /etc/nginx/certs/clubs.iiit.ac.in.chain.pem;
+	add_header Strict-Transport-Security "max-age=31536000" always;
+	include /etc/nginx/vhost.d/default;
+	location / {
+		proxy_pass http://dev.clubs.iiit.ac.in;
+	}
+}

--- a/nginx/life.iiit.ac.in.conf
+++ b/nginx/life.iiit.ac.in.conf
@@ -1,0 +1,19 @@
+server {
+	server_name life.iiit.ac.in;
+	listen 443 ssl http2 ;
+	access_log /var/log/nginx/access.log vhost;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/ssl/iiit.ac.in.pem;
+	ssl_certificate_key /etc/ssl/iiit.ac.in.pem;
+	# ssl_dhparam /etc/ssl/certs/clubs.iiit.ac.in.dhparam.pem;
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	ssl_trusted_certificate /etc/ssl/iiit.ac.in.pem;
+	add_header Strict-Transport-Security "max-age=31536000" always;
+	include /etc/nginx/vhost.d/default;
+	location / {
+		proxy_pass http://clubs.iiit.ac.in;
+	}
+}


### PR DESCRIPTION
## Reason

Due to a file size limit in nginx, that only 4096  is allowed, we are not able to load a big nginx configuraiton file.
Link - <https://serverfault.com/a/1069193>

## Changes

Split the configuration accross files, to potentially fix that